### PR TITLE
make the virsh run after the udev script to fix a "failed to find host usb device" error

### DIFF
--- a/usb-libvirt-hotplug.sh
+++ b/usb-libvirt-hotplug.sh
@@ -99,6 +99,7 @@ DEVNUM=$((10#$DEVNUM))
 # update XML from stdin.
 #
 echo "Running virsh ${COMMAND} ${DOMAIN} for USB bus=${BUSNUM} device=${DEVNUM}:" >&2
+cat <<ENDAT | at now
 virsh "${COMMAND}" "${DOMAIN}" /dev/stdin <<END
 <hostdev mode='subsystem' type='usb'>
   <source>
@@ -106,3 +107,4 @@ virsh "${COMMAND}" "${DOMAIN}" /dev/stdin <<END
   </source>
 </hostdev>
 END
+ENDAT


### PR DESCRIPTION
virsh was throwning the following error:  
`558: error : qemuMonitorJSONCheckError:394 : internal error: unable to execute QEMU command 'device_add': failed to find host usb device`

Running the scipt manually was working fine. After some testing, it seemed that the usb device was not fully available yet when the udev script was running. Runnning virsh slightly after udev using the `at` command fixed the issue.