### PR TITLE
Tolerate new udev actions "bind" and "unbind"

### DIFF
--- a/usb-libvirt-hotplug.sh
+++ b/usb-libvirt-hotplug.sh
@@ -67,8 +67,8 @@ if [ "${ACTION}" == 'add' ]; then
 elif [ "${ACTION}" == 'remove' ]; then
   COMMAND='detach-device'
 else
-  echo "Invalid udev ACTION: ${ACTION}" >&2
-  exit 1
+  echo "Ignored udev ACTION: ${ACTION}" >&2
+  exit 0
 fi
 
 if [ -z "${BUSNUM}" ]; then


### PR DESCRIPTION
Recent kernel and udev versions have added new actions that are triggered on top of the usual add and remove actions. This causes the script to `exit 1` every time, which appears as a warning in udev logs. While not a big deal, this is ugly. This patch fixes that and protects us against future new events as well.