### PR TITLE
Fixed script to attach on action bind.

### DIFF
--- a/usb-libvirt-hotplug.sh
+++ b/usb-libvirt-hotplug.sh
@@ -64,6 +64,8 @@ if [ -z "${ACTION}" ]; then
 fi
 if [ "${ACTION}" == 'add' ]; then
   COMMAND='attach-device'
+elif [ "${ACTION}" == 'bind' ]; then
+  COMMAND='attach-device'
 elif [ "${ACTION}" == 'remove' ]; then
   COMMAND='detach-device'
 else


### PR DESCRIPTION
On Ubuntu 20.04.4 LTS, I am getting a `bind` action instead of an `add` action when a new USB device is plugged in. This change to the script will attach the USB device on an `add` or a `bind` command.